### PR TITLE
feat: Add eye button to hide and show menu and bgcolor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,7 @@ function App() {
         )}
 
         <div className="container w-[90%] gsm:min-h-[100dvh] flex flex-col justify-center items-center gap-[2rem] font-primary m-auto gsm:m-0">
-          <div className="flex items-center gap-16">
+          <div className="flex items-center gap-14">
             {showMenuAndBgColor && (
               <Menu
                 isDrawing={isDrawing}
@@ -54,7 +54,7 @@ function App() {
               />
             )}
             <div
-              className={`clearAll bg-[#CBCCCF] p-[1rem] text-[2rem] rounded-[50%] shadow-lg hover:bg-gray-400 cursor-pointer ${
+              className={`clearAll bg-[#CBCCCF] p-[1rem] text-[1.5rem] rounded-[50%] shadow-lg hover:bg-gray-400 cursor-pointer ${
                 !showMenuAndBgColor && "mt-12"
               }`}
               onClick={() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { startDrawing, clearCanvas } from "./utils/canvas";
 import Menu from "./components/Menu";
 import BgColor from "./components/BgColor";
 import { rainbowColors } from "./utils/helpers";
+import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 
 function App() {
   const canvasRef = useRef(null);
@@ -11,6 +12,8 @@ function App() {
   const [thickness, setThickness] = useState(10);
   const [color, setColor] = useState("#000");
   const [bgColor, setBgColor] = useState("#B7BABF");
+
+  const [showMenuAndBgColor, setShowMenuAndBgColor] = useState(true);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -22,27 +25,45 @@ function App() {
   return (
     <>
       <div className="bg-[#d3d5d8] flex flex-col min-w-[100dvw] justify-center gsm:flex-row">
-        <div className="gsm:w-[10%] w-[85%] py-8 grid grid-cols-6 vsm:grid-cols-4 gsm:grid-cols-1 gap-2 vsm:gap-4 gsm:gap-2 gsm:py-[5rem] gsm:mb-8 mx-auto">
-          {rainbowColors?.map((val, i) => (
-            <BgColor
-              key={i}
-              color={val}
-              setBgColor={setBgColor}
-              canvas={canvasRef.current}
-            />
-          ))}
-        </div>
+        {showMenuAndBgColor && (
+          <div className="gsm:w-[10%] w-[85%] py-7 grid grid-cols-6 vsm:grid-cols-4 gsm:grid-cols-1 gap-2 vsm:gap-4 gsm:gap-2 gsm:py-[5rem] gsm:mb-8 mx-auto">
+            {rainbowColors?.map((val, i) => (
+              <BgColor
+                key={i}
+                color={val}
+                setBgColor={setBgColor}
+                canvas={canvasRef.current}
+              />
+            ))}
+          </div>
+        )}
 
         <div className="container w-[90%] gsm:min-h-[100dvh] flex flex-col justify-center items-center gap-[2rem] font-primary m-auto gsm:m-0">
-          <Menu
-            isDrawing={isDrawing}
-            setIsDrawing={setIsDrawing}
-            thickness={thickness}
-            setThickness={setThickness}
-            color={color}
-            setColor={setColor}
-            canvasRef={canvasRef}
-          />
+          <div className="flex items-center gap-16">
+            {showMenuAndBgColor && (
+              <Menu
+                isDrawing={isDrawing}
+                setIsDrawing={setIsDrawing}
+                thickness={thickness}
+                setThickness={setThickness}
+                color={color}
+                setColor={setColor}
+                canvasRef={canvasRef}
+                showMenuAndBgColor={showMenuAndBgColor}
+                setShowMenuAndBgColor={setShowMenuAndBgColor}
+              />
+            )}
+            <div
+              className={`clearAll bg-[#CBCCCF] p-[1rem] text-[2rem] rounded-[50%] shadow-lg hover:bg-gray-400 cursor-pointer ${
+                !showMenuAndBgColor && "mt-12"
+              }`}
+              onClick={() => {
+                setShowMenuAndBgColor((state) => !state);
+              }}
+            >
+              {showMenuAndBgColor ? <FaRegEyeSlash /> : <FaRegEye />}
+            </div>
+          </div>
           <canvas
             id="draw"
             className={`whiteboard bg-[#DBDCDF] rounded-[0.6rem] shadow-mdm ${


### PR DESCRIPTION
<!-- Mention the following details and these are mandatory -->
# Issue Title: [FEAT] Option to Hide the buttons and bg choices
*resolve issue:* #38 

## Type of change ☑️

Added an eye button, toggling which can hide or show the menu and bgcolors. (Default show).
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist: ☑️

- [x] My code follows the code style of this project.
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added things that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.


 
## How Has This Been Tested? ⚙️

I verified them on my own visually.
