### PR TITLE
Bug solved: Persistent Drawing After Exiting Canvas #268

### DIFF
--- a/src/utils/canvas.js
+++ b/src/utils/canvas.js
@@ -83,6 +83,7 @@ export function startDrawing(
     isDrawing = false;
   });
 
+  canvas.addEventListener("mouseleave", () => (isDrawing = false));
   canvas.addEventListener("touchmove", (e) => {
     // added e.preventDefault();
     e.preventDefault();


### PR DESCRIPTION
# Issue Title: Persistent Drawing After Exiting Canvas
*resolve issue:* #268 

## Type of change ☑️

What sort of change have you made:
- Now when i draw someting and accidently out of the canvas and then when we back to canvas even if i dont click the mouse it don't draws.

## Checklist: ☑️
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added things that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## How Has This Been Tested? ⚙️

The fix has been tested by performing the following steps:
1. Added the event listener `canvas.addEventListener("mouseleave", () => (isDrawing = false));` to the canvas.
2. Drew on the canvas and moved the cursor out of the canvas area while holding down the mouse button.
3. Re-entered the canvas area without clicking the mouse.
4. Verified that drawing does not continue unless the mouse button is clicked again.
5. Repeated the steps multiple times to ensure consistency and that the issue no longer occurs.
6. Tested on different browsers (Chrome, Firefox, Safari) and different operating systems (Windows, macOS) to confirm the fix works across platforms.
