### PR TITLE
added the guidelines logo to the right, fixed logo wrt to the guidelines , easy flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,6 +74,7 @@ function App() {
         </div>
 
         <button className="absolute top-7 right-6 p-3 bg-gray-800 rounded-full text-white hover:bg-gray-600 transition duration-300">
+          
           <FaBookOpen
             size={35}
             color="white"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,9 +73,9 @@ function App() {
           <p className="text-gray-500 text-xs">All you need is a canvas to craft your ideas.</p>
         </div>
 
-        <button className="absolute top-0 left-0 p-6">
+        <button className="absolute top-7 right-6 p-3 bg-gray-800 rounded-full text-white hover:bg-gray-600 transition duration-300">
           <FaBookOpen
-            size={28}
+            size={35}
             color="white"
             className="bg-black p-1 rounded-xl"
             aria-label="show-guidelines"


### PR DESCRIPTION
<!-- Mention the following details and these are mandatory -->
# Issue Title: guidelines icon button 
*resolve issue:* #227 

## Type of change ☑️

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x ] Bug fix (non-breaking change which fixes an issue)


## Checklist: ☑️
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ x] My code follows the guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [ x] My changes generate no new warnings.
- [x ] I have added things that prove my fix is effective or that my feature works.

 
## How Has This Been Tested? ⚙️

Before the book or guideline icon came on left and when clicked on it the guidelines came on the right side of the page and to close it we have to go to the right and close, Now i added the icon to the right only ,when clicked  guidelines appear there itself and can be closed easily . Also added some hover effect to it.
![Screenshot_20240606_131900](https://github.com/singodiyashubham87/Draw-it-out/assets/121295967/ef0046d8-6f62-4fd2-a89e-836bfd013c48)
![Screenshot_20240606_131915](https://github.com/singodiyashubham87/Draw-it-out/assets/121295967/69f34e0b-a53e-4c04-93e5-f6b5e37f018c)
![Screenshot_20240606_131925](https://github.com/singodiyashubham87/Draw-it-out/assets/121295967/6eb048d1-23b8-48dd-aaab-e17b359798db)

