### PR TITLE
 Dark mode gets reset on refreshing the page.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,9 @@ function App() {
   const [thickness, setThickness] = useState(4);
   const [color, setColor] = useState("#000");
   const [bgColor, setBgColor] = useState("#b7babf");
-  const [darkMode, setDarkMode] = useState(null);
+  const [darkMode, setDarkMode] = useState(() =>{
+    return localStorage.getItem('darkMode') === 'true' ;
+  });
   const [showMenuAndBgColor, setShowMenuAndBgColor] = useState(true);
   const [steps] = useState(tourSteps);
   const [modal, setModal] = useState(false);
@@ -58,10 +60,27 @@ function App() {
     }
   }, [bgColor, color, thickness, canvasInitialized, brushStyle]);
 
-  const toggleDarkMode = () => {
-    setDarkMode(!darkMode);
-    document.body.classList.toggle("dark");
-  };
+  // const toggleDarkMode = () => {
+  //   setDarkMode(!darkMode);
+  //   document.body.classList.toggle("dark");
+  // };
+
+    useEffect(() => {
+      if(darkMode){
+     document.body.classList.add('dark');
+      }
+      else{
+        document.body.classList.remove('dark');
+      }
+    },[darkMode])  ;
+
+    const toggleDarkMode = () => {
+     setDarkMode(prevMode => {
+      const newMode = !prevMode ;
+      localStorage.setItem('darkMode' , newMode) ;
+      return newMode ;
+     });
+    };
 
   return (
     <>


### PR DESCRIPTION
This PR works on resolving an issue which is that on refreshing a page, Dark mode gets reset.

Fixes #289 

Before refreshing the page,
![Screenshot 2024-06-07 161208](https://github.com/singodiyashubham87/Draw-it-out/assets/141627570/01428fcd-b158-44e7-a270-7d47d195fe54)

After refreshing the page,
![Screenshot 2024-06-07 161235](https://github.com/singodiyashubham87/Draw-it-out/assets/141627570/cce5a20a-2606-4dc9-b978-16eed7539031)

it can be done in such a way that:
->Initialize dark mode state from local storage.
->Apply dark mode class on state change.
->Toggle dark mode and save preference to local Storage.