### PR TITLE
moved the guideline button to right for better flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -88,7 +88,7 @@ function App() {
           <p className="text-gray-500 text-xs">All you need is a canvas to craft your ideas.</p>
         </div>
 
-        <button className="absolute top-0 left-0 p-6">
+        <button className="absolute top-7 right-6 p-3 bg-gray-800 rounded-full text-white hover:bg-gray-600 transition duration-300">
           <FaBookOpen
             size={28}
             color="white"


### PR DESCRIPTION
<!-- Mention the following details and these are mandatory -->
# Issue Title: 
*closes* #227 

## Type of change ☑️

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x ] Bug fix (non-breaking change which fixes an issue)


## Checklist: ☑️
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [ x] My code follows the guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] My changes generate no new warnings.
- [ x] I have added things that prove my fix is effective or that my feature works.



 
## How Has This Been Tested? ⚙️
![Screenshot_20240606_131925](https://github.com/singodiyashubham87/Draw-it-out/assets/121295967/a44c94ff-d8b1-4d27-8230-b6637abfb37a)
![Screenshot_20240606_131915](https://github.com/singodiyashubham87/Draw-it-out/assets/121295967/d8f26f88-07cf-4f45-9268-95012407f4f9)
![Screenshot_20240606_131900](https://github.com/singodiyashubham87/Draw-it-out/assets/121295967/c98c0694-a4e8-4ab4-b0bb-2608b4b5e6ce)

Before the book or guideline icon came on left and when clicked on it the guidelines came on the right side of the page and to close it we have to go to the right and close, Now i added the icon to the right only ,when clicked guidelines appear there itself and can be closed easily . Also added some hover effect to it.

